### PR TITLE
feat: expose & document `JsonError`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,9 @@ pub mod prelude;
 pub mod test_utils;
 pub mod utils;
 
+/// The format of error responses from preroll's error handling middleware.
+pub use middleware::json_error::JsonError;
+
 /// The result type which is expected from functions passed to `preroll::main!`.
 ///
 /// This is a `color_eyre::eyre::Result<T>`.


### PR DESCRIPTION
This is so that downstream consumers can use this as documentation of the `JsonError` structure but also possibly use it directly.

![Screenshot from 2021-01-11 15-11-49](https://user-images.githubusercontent.com/1093990/104248988-6b8c2c80-541f-11eb-87e6-5071f349cd45.png)
