### PR TITLE
feat: more test_utils assertion helpers

### DIFF
--- a/preroll-main-test/tests/test-preroll-main.rs
+++ b/preroll-main-test/tests/test-preroll-main.rs
@@ -40,8 +40,7 @@ async fn test_preroll_main() {
                 400,
                 "failed with reason: missing field `param`",
             )
-            .await
-            .unwrap();
+            .await;
         }
 
         {
@@ -68,8 +67,7 @@ async fn test_preroll_main() {
                 500,
                 "Internal Server Error (correlation_id=00000000-0000-0000-0000-000000000000)",
             )
-            .await
-            .unwrap();
+            .await;
         }
     });
 

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -265,8 +265,8 @@ where
 ///         404,
 ///         "(no additional context)",
 ///     )
-///     .await
-///     .unwrap();
+///     .await;
+///
 ///     Ok(())
 /// }
 /// ```
@@ -275,8 +275,7 @@ pub async fn assert_json_error<Status>(
     mut res: impl AsMut<http::Response>,
     status: Status,
     err_msg: &str,
-) -> TestResult<()>
-where
+) where
     Status: TryInto<StatusCode>,
     Status::Error: Debug,
 {
@@ -286,14 +285,14 @@ where
         .try_into()
         .expect("test must specify valid status code");
 
-    let str_response = res.body_string().await?;
+    let str_response = res.body_string().await.unwrap();
 
     let error: JsonError = serde_json::from_str(&str_response).map_err(|e| {
         surf::Error::from_str(
             res.status(),
             format!("Error, could not parse Response into JsonError! json err: \"{}\", response body: \"{}\"", e, str_response)
         )
-    })?;
+    }).unwrap();
 
     assert_eq!(res.status(), status);
     assert_eq!(&error.title, status.canonical_reason());
@@ -315,8 +314,6 @@ where
         assert_eq!(error.correlation_id, None);
         assert!(res.header("X-Correlation-Id").is_none());
     }
-
-    Ok(())
 }
 
 /// Assert that a response has a status code and parse out the body to JSON if possible.

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -8,8 +8,8 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use cfg_if::cfg_if;
-use surf::{Client, Response, StatusCode, Url};
-use tide::Server;
+use surf::{Client, StatusCode, Url};
+use tide::{http, Server};
 
 use crate::logging::{log_format_json, log_format_pretty};
 use crate::middleware::{JsonErrorMiddleware, LogMiddleware, RequestIdMiddleware};
@@ -272,7 +272,7 @@ where
 /// ```
 #[allow(dead_code)] // Not actually dead code. (??)
 pub async fn assert_json_error<Status>(
-    res: &mut Response,
+    mut res: impl AsMut<http::Response>,
     status: Status,
     err_msg: &str,
 ) -> TestResult<()>
@@ -280,6 +280,8 @@ where
     Status: TryInto<StatusCode>,
     Status::Error: Debug,
 {
+    let res = res.as_mut();
+
     let status: StatusCode = status
         .try_into()
         .expect("test must specify valid status code");
@@ -338,7 +340,7 @@ where
 /// }
 /// ```
 pub async fn assert_status_json<StructType, Status>(
-    res: &mut Response,
+    mut res: impl AsMut<http::Response>,
     status: Status,
 ) -> StructType
 where
@@ -346,6 +348,8 @@ where
     Status: TryInto<StatusCode>,
     Status::Error: Debug,
 {
+    let res = res.as_mut();
+
     let status: StatusCode = status
         .try_into()
         .expect("test must specify valid status code");
@@ -381,11 +385,13 @@ where
 ///     Ok(())
 /// }
 /// ```
-pub async fn assert_status<Status>(res: &mut Response, status: Status)
+pub async fn assert_status<Status>(mut res: impl AsMut<http::Response>, status: Status)
 where
     Status: TryInto<StatusCode>,
     Status::Error: Debug,
 {
+    let res = res.as_mut();
+
     let status: StatusCode = status
         .try_into()
         .expect("test must specify valid status code");


### PR DESCRIPTION
On an internal project we found that basic assertions often led to output that difficult to act on. This adds some assertion helpers that always print out the body in the failure message if there is a failure.