### PR TITLE
feat: intial /monitor/status built-in endpoint

### DIFF
--- a/preroll-main-test/Cargo.toml
+++ b/preroll-main-test/Cargo.toml
@@ -13,6 +13,7 @@ test = ["preroll/test", "preroll/custom_middleware"]
 [dependencies]
 futures-lite = "1.11.2"
 preroll = { path = "../", features = ["test"] }
+serde_json = "1.0.58"
 
 [dependencies.serde]
 version = "1.0.116"

--- a/preroll-main-test/tests/test-preroll-main.rs
+++ b/preroll-main-test/tests/test-preroll-main.rs
@@ -57,6 +57,26 @@ async fn test_preroll_main() {
             assert_eq!(response, "preroll-main-test");
         }
 
+        {
+            let url = format!("http://127.0.0.1:{}/monitor/status", port);
+            let response = surf::get(url).recv_string().await.unwrap();
+
+            #[derive(serde::Deserialize)]
+            struct Status {
+                git: String,
+                // hostname: String,
+                service: String,
+                uptime: f64,
+            }
+
+            let status: Status = serde_json::from_str(&response).unwrap();
+
+            assert_eq!(status.git, "No GIT_COMMIT environment variable.");
+            // assert_eq!(status.hostname, "hostname");
+            assert_eq!(status.service, "preroll-main-test");
+            assert!(status.uptime > 0.0);
+        }
+
         #[cfg(debug_assertions)]
         {
             let url = format!("http://127.0.0.1:{}/internal-error", port);

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -1,0 +1,1 @@
+pub mod monitor;

--- a/src/builtins/monitor.rs
+++ b/src/builtins/monitor.rs
@@ -1,0 +1,81 @@
+use std::env;
+use std::sync::Arc;
+use std::time::Instant;
+
+use once_cell::sync::OnceCell;
+use serde::Serialize;
+use tide::{Body, Server};
+
+static SERVICE_NAME: OnceCell<&'static str> = OnceCell::new();
+static START_TIME: OnceCell<Instant> = OnceCell::new();
+
+pub fn setup_monitor<State>(service_name: &'static str, server: &mut Server<Arc<State>>)
+where
+    State: Send + Sync + 'static,
+{
+    SERVICE_NAME.set(service_name).ok();
+    START_TIME.set(Instant::now()).ok();
+
+    server.at("/monitor/ping").get(|_| async {
+        Ok(*SERVICE_NAME
+            .get()
+            .unwrap_or(&"service name not initialized"))
+    });
+
+    server.at("/monitor/status").get(|_| async {
+        let status = Status {
+            git: env::var("GIT_COMMIT")
+                .unwrap_or_else(|_| "No GIT_COMMIT environment variable.".to_string()),
+            hostname: env::var("HOST")
+                .unwrap_or_else(|_| "No HOST environment variable.".to_string()),
+            service: *SERVICE_NAME
+                .get()
+                .unwrap_or(&"service name not initialized"),
+            uptime: START_TIME
+                .get()
+                .map(|start| start.elapsed().as_secs_f64())
+                .unwrap_or(f64::NEG_INFINITY),
+        };
+
+        Ok(Body::from_json(&status)?)
+    });
+}
+
+#[derive(Serialize)]
+struct Status {
+    git: String,
+    hostname: String,
+    service: &'static str,
+    uptime: f64,
+}
+
+// TODO(Jeremiah):
+//
+// Add more status fields, similar to Boltzmann.js:
+//
+// {
+//     "downstream": {
+//         "postgresReachability": {
+//             "error": null,
+//             "latency": 2,
+//             "status": "healthy"
+//         },
+//         "redisReachability": {
+//             "error": null,
+//             "latency": 2,
+//             "status": "healthy"
+//         }
+//     },
+//     "memory": {
+//         "rss": 87212032
+//     },
+//     "stats": {
+//         "requestCount": 63425,
+//         "statuses": {
+//             "200": 50024,
+//             "202": 7963,
+//             "204": 5404,
+//             "500": 34
+//         }
+//     },
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@
 #[cfg(all(not(debug_assertions), feature = "panic-on-error"))]
 compile_error!("The \"panic-on-error\" feature must not be used in production, and is not available with `--release`.");
 
+pub(crate) mod builtins;
 pub(crate) mod logging;
 pub(crate) mod middleware;
 

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -11,10 +11,10 @@ use cfg_if::cfg_if;
 use surf::{Client, StatusCode, Url};
 use tide::{http, Server};
 
+use crate::builtins::monitor::setup_monitor;
 use crate::logging::{log_format_json, log_format_pretty};
-use crate::middleware::{JsonErrorMiddleware, LogMiddleware, RequestIdMiddleware};
-
 use crate::middleware::json_error::JsonError;
+use crate::middleware::{JsonErrorMiddleware, LogMiddleware, RequestIdMiddleware};
 
 #[cfg(feature = "honeycomb")]
 use tracing_subscriber::Registry;
@@ -188,9 +188,7 @@ where
     server.with(LogMiddleware::new());
     server.with(JsonErrorMiddleware::new());
 
-    server
-        .at("/monitor/ping")
-        .get(|_| async { Ok("preroll_test_utils") });
+    setup_monitor("preroll_test_utils", &mut server);
 
     setup_routes_fn(&mut server);
 


### PR DESCRIPTION
This adds a `GET /monitor/status` which returns some handy data for human operators.

This is formatted similar to Boltzmann.js's equivalent endpoint, and is akin to the `/health` draft RFC.