### PR TITLE
fix: do not error on invalid trace ids

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
+    - name: update clippy
+      run: rustup toolchain update stable
+
     - name: install nightly
       run: rustup toolchain install nightly
 

--- a/src/middleware/requestid.rs
+++ b/src/middleware/requestid.rs
@@ -31,7 +31,13 @@ impl RequestIdMiddleware {
         let request_id: RequestId;
         #[cfg(not(feature = "test"))]
         if let Some(header) = req.header("X-Request-Id") {
-            request_id = header.last().as_str().parse()?;
+            request_id = match header.last().as_str().parse() {
+                Ok(id) => id,
+                Err(e) => {
+                    log::warn!("Invalid X-Request-Id: \"{}\" - Error: {}", header, e);
+                    RequestId::new()
+                }
+            };
         } else {
             request_id = RequestId::new();
         }


### PR DESCRIPTION
The only real reason we parse these to begin with is because tracing-honeycomb requires it, despite that Honecomb explicitly specifies that ids are arbitrary and opaque and should not be parsed.