### PR TITLE
fix,deps: use eaze-honeycomb-tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ all = ["honeycomb", "postgres"] # All add-ons
 
 honeycomb = ["_beeline", "_tracing", "libhoney-rust"]
 _beeline = ["base64", "thiserror"]
-_tracing = ["tracing", "tracing-futures", "tracing-honeycomb", "tracing-subscriber"]
+_tracing = ["tracing", "tracing-futures", "eaze-tracing-honeycomb", "tracing-subscriber"]
 
 postgres = ["sqlx", "tide-sqlx"]
 
@@ -119,8 +119,8 @@ optional = true
 version = "0.2.4"
 optional = true
 
-[dependencies.tracing-honeycomb]
-version = "0.1.0"
+[dependencies.eaze-tracing-honeycomb]
+version = "0.2.1-eaze.1"
 optional = true
 
 [dependencies.tracing-subscriber]

--- a/src/middleware/json_error.rs
+++ b/src/middleware/json_error.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use tide::{Body, Middleware, Next, Request, Result};
 
 #[cfg(feature = "honeycomb")]
-use tracing_honeycomb::TraceId;
+use eaze_tracing_honeycomb::TraceId;
 
 #[cfg(feature = "test")]
 use uuid::Uuid;

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -3,7 +3,7 @@ use tide::http::headers::{REFERER, USER_AGENT};
 use tide::{Middleware, Next, Request, Result};
 
 #[cfg(feature = "honeycomb")]
-use tracing_honeycomb::TraceId;
+use eaze_tracing_honeycomb::TraceId;
 
 use super::extension_types::{CorrelationId, RequestId};
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -17,7 +17,7 @@ use crate::builtins::monitor::setup_monitor;
 
 cfg_if! {
     if #[cfg(feature = "honeycomb")] {
-        use tracing_honeycomb::{new_blackhole_telemetry_layer, new_honeycomb_telemetry_layer};
+        use eaze_tracing_honeycomb::{new_blackhole_telemetry_layer, new_honeycomb_telemetry_layer};
         use tracing_subscriber::filter::LevelFilter;
         use tracing_subscriber::prelude::*;
         use tracing_subscriber::Registry;


### PR DESCRIPTION
This fixes various issues with tracing-honeycomb.

Refs: https://github.com/inanna-malick/tracing-honeycomb/pull/15
Refs: https://github.com/inanna-malick/tracing-honeycomb/pull/16

This also gets us other unreleased commits, allowing us to do per-trace sampling.