### PR TITLE
Logging tracing monitor improvements

### DIFF
--- a/src/builtins/monitor.rs
+++ b/src/builtins/monitor.rs
@@ -37,7 +37,7 @@ where
                 .unwrap_or(f64::NEG_INFINITY),
         };
 
-        Ok(Body::from_json(&status)?)
+        Body::from_json(&status)
     });
 }
 

--- a/src/builtins/monitor.rs
+++ b/src/builtins/monitor.rs
@@ -6,6 +6,8 @@ use once_cell::sync::OnceCell;
 use serde::Serialize;
 use tide::{Body, Server};
 
+use crate::utils::HOSTNAME;
+
 static SERVICE_NAME: OnceCell<&'static str> = OnceCell::new();
 static START_TIME: OnceCell<Instant> = OnceCell::new();
 
@@ -26,8 +28,7 @@ where
         let status = Status {
             git: env::var("GIT_COMMIT")
                 .unwrap_or_else(|_| "No GIT_COMMIT environment variable.".to_string()),
-            hostname: env::var("HOST")
-                .unwrap_or_else(|_| "No HOST environment variable.".to_string()),
+            hostname: &*HOSTNAME,
             service: *SERVICE_NAME
                 .get()
                 .unwrap_or(&"service name not initialized"),
@@ -42,9 +43,9 @@ where
 }
 
 #[derive(Serialize)]
-struct Status {
+struct Status<'host> {
     git: String,
-    hostname: String,
+    hostname: &'host str,
     service: &'static str,
     uptime: f64,
 }

--- a/src/logging/json.rs
+++ b/src/logging/json.rs
@@ -1,12 +1,9 @@
 use std::io::Write;
 use std::{io, process};
 
-use lazy_static::lazy_static;
 use log::kv;
 
-lazy_static! {
-    static ref HOSTNAME: String = gethostname::gethostname().to_string_lossy().to_string();
-}
+use crate::utils::HOSTNAME;
 
 // Modified from the json_env_logger crate
 pub fn log_format_json<F>(f: &mut F, record: &log::Record<'_>) -> io::Result<()>

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,12 @@
 //! Miscellaneous utilities.
 
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub(crate) static ref HOSTNAME: String =
+        gethostname::gethostname().to_string_lossy().to_string();
+}
+
 /// This function is useful for inspecting variables that rust-analyzer has trouble extracting type information for,
 /// namely returns from awaited futures.
 ///


### PR DESCRIPTION
- feat: reorder json log fields
    - This makes it easier to read - by likely order of property importance - in plaintext tools.
- fix: correctly resolve hostname in /monitor/status
    - Guess I forgot about this the first time.
- feat: (Honeycomb) send Request/Response info
    - This stuff would be very useful for filtering and/or grouping in honeycomb.

