### PR TITLE
Remove underscore from write_key in HONEYCOMB_WRITE_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ features = ["honeycomb", "postgres"]
 
 #### List of optional add-on features:
 - `"honeycomb"`: Enables tracing to [honeycomb.io].
-    - Env variable `HONEYCOMBIO_WRITE_KEY` (required).
+    - Env variable `HONEYCOMB_WRITEKEY` (required).
+    - Env variable `HONEYCOMB_API_HOST`, sets upstream event proxy.
     - Env variable `TRACELEVEL`, sets the tracing level filter, defaults to `info`.
-    - Writes to a dataset named `{service_name}-{environment}`.
+    - Env variable `HONEYCOMB_DATASET`, sets the dataset name, defaults to `{service_name}-{environment}`.
         - `service_name` is from `preroll::main!("service_name", ...)`.
         - `environment` is from `ENVIRONMENT`, or defaults to `"development"`.
 - `"postgres"`: Enables a postgres connection pool with transactions.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -145,7 +145,7 @@ pub fn initial_setup(service_name: &'static str) -> Result<()> {
             .map(|v| v.parse())
             .unwrap_or(Ok(LevelFilter::INFO))?;
 
-        if let Ok(api_key) = env::var("HONEYCOMB_WRITE_KEY") {
+        if let Ok(api_key) = env::var("HONEYCOMB_WRITEKEY") {
             let dataset = env::var("HONEYCOMB_DATASET")
                 .unwrap_or_else(|_| format!("{}-{}", service_name, environment));
 


### PR DESCRIPTION
Following the recent removal of `IO`, I noticed that the standardized name for this env variable doesn't include a `_` between write and key.

This removes that underscore to more fully standardize the naming format. This is a breaking change.

I also updated the readme to reflect the updated support for `HONEYCOMB_API_HOST` and the optional `HONEYCOMB_DATASET` env variable.

