### PR TITLE
change: always default log level to 'info'

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The following environment variables are read during `preroll::main!`:
 - `ENVIRONMENT`: If this starts with `prod`, load the production-mode JSON logger, avoid `.env`.
 - `FORCE_DOTENV`: Override production-mode, force-load environment from `.env`.
 - `HOST`: Sets the hostname that this service will listen on. Defaults to `"127.0.0.1"`.
-- `LOGLEVEL`: Set the logger's level filter, defaults to `info` in production-mode, `debug` in development-mode.
+- `LOGLEVEL`: Set the logger's level filter, defaults to `info`.
 - `PORT`: Sets the port that this service will listen on. Defaults to `8080`.
 
 ### Note:

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -105,9 +105,9 @@ where
 pub fn initial_setup(service_name: &'static str) -> Result<()> {
     color_eyre::install()?;
 
-    let log_level: log::LevelFilter;
-    let log_level_from_env = env::var("LOGLEVEL")
-        .map(|v| v.parse().expect("LOGLEVEL must be a valid log level."));
+    let log_level = env::var("LOGLEVEL")
+        .map(|v| v.parse().expect("LOGLEVEL must be a valid log level."))
+        .unwrap_or(log::LevelFilter::Info);
 
     if env::var("FORCE_DOTENV").is_ok() || env::var("DEBUG_DOTENV").is_ok() {
         dotenv::dotenv().ok();
@@ -117,9 +117,6 @@ pub fn initial_setup(service_name: &'static str) -> Result<()> {
 
     // Logging
     if environment.starts_with("prod") {
-        // Production
-        log_level = log_level_from_env.unwrap_or(log::LevelFilter::Info);
-
         env_logger::builder()
             .format(log_format_json)
             .filter_level(log_level)
@@ -128,8 +125,6 @@ pub fn initial_setup(service_name: &'static str) -> Result<()> {
     } else {
         // Development
         dotenv::dotenv().ok();
-
-        log_level = log_level_from_env.unwrap_or(log::LevelFilter::Debug);
 
         env_logger::builder()
             .format(log_format_pretty)


### PR DESCRIPTION
Debug usually isn't desirable locally either except when you want to explicitly turn it on. Usually it is too noisy.