### PR TITLE
feat: drab, dull ping responses a thing of the past

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ lazy_static = "1.4"
 log = "0.4"
 once_cell = "1.5"
 serde_json = "1.0"
+petname = "1.1.1"
 
 [dependencies.async-std]
 version = "1.8"

--- a/preroll-example/tests/networked.rs
+++ b/preroll-example/tests/networked.rs
@@ -58,7 +58,7 @@ async fn test_preroll_main_networked() {
             let url = format!("http://127.0.0.1:{}/monitor/ping", port);
             let response = surf::get(url).recv_string().await.unwrap();
 
-            assert_eq!(response, "preroll-example");
+            assert!(!response.is_empty());
         }
 
         {

--- a/preroll-example/tests/networked.rs
+++ b/preroll-example/tests/networked.rs
@@ -71,6 +71,7 @@ async fn test_preroll_main_networked() {
                 // hostname: String,
                 service: String,
                 uptime: f64,
+                ping: String,
             }
 
             let status: Status = serde_json::from_str(&response).unwrap();
@@ -79,6 +80,7 @@ async fn test_preroll_main_networked() {
             // assert_eq!(status.hostname, "hostname");
             assert_eq!(status.service, "preroll-example");
             assert!(status.uptime > 0.0);
+            assert!(!status.ping.is_empty());
         }
 
         #[cfg(debug_assertions)]

--- a/src/builtins/monitor.rs
+++ b/src/builtins/monitor.rs
@@ -40,6 +40,7 @@ where
                 .get()
                 .map(|start| start.elapsed().as_secs_f64())
                 .unwrap_or(f64::NEG_INFINITY),
+            ping: PING_RESPONSE.to_string(),
         };
 
         Body::from_json(&status)
@@ -52,6 +53,7 @@ struct Status<'host> {
     hostname: &'host str,
     service: &'static str,
     uptime: f64,
+    ping: String,
 }
 
 // TODO(Jeremiah):

--- a/src/builtins/monitor.rs
+++ b/src/builtins/monitor.rs
@@ -11,6 +11,12 @@ use crate::utils::HOSTNAME;
 static SERVICE_NAME: OnceCell<&'static str> = OnceCell::new();
 static START_TIME: OnceCell<Instant> = OnceCell::new();
 
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref PING_RESPONSE: String = petname::petname(2, "-");
+}
+
 pub fn setup_monitor<State>(service_name: &'static str, server: &mut Server<Arc<State>>)
 where
     State: Send + Sync + 'static,
@@ -18,11 +24,9 @@ where
     SERVICE_NAME.set(service_name).ok();
     START_TIME.set(Instant::now()).ok();
 
-    server.at("/monitor/ping").get(|_| async {
-        Ok(*SERVICE_NAME
-            .get()
-            .unwrap_or(&"service name not initialized"))
-    });
+    server
+        .at("/monitor/ping")
+        .get(|_| async { Ok(PING_RESPONSE.as_str()) });
 
     server.at("/monitor/status").get(|_| async {
         let status = Status {

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -19,7 +19,7 @@
 //!     let mut res = client.get("/monitor/ping").await.unwrap();
 //!
 //!     let body = assert_status(&mut res, 200).await;
-//!     assert_eq!(body, "preroll_test_utils");
+//!     assert!(!body.is_empty());
 //!     Ok(())
 //! }
 //! ```
@@ -80,7 +80,7 @@ pub type TestResult<T> = surf::Result<T>;
 ///     let mut res = client.get("/monitor/ping").await.unwrap();
 ///
 ///     let body = assert_status(&mut res, 200).await;
-///     assert_eq!(body, "preroll_test_utils");
+///     assert!(!body.is_empty());
 ///     Ok(())
 /// }
 /// ```
@@ -447,7 +447,7 @@ where
 ///     let mut res = client.get("/monitor/ping").await.unwrap();
 ///
 ///     let body = assert_status(&mut res, 200).await;
-///     assert_eq!(body, "preroll_test_utils");
+///     assert!(body.contains("-"));
 ///     Ok(())
 /// }
 /// ```


### PR DESCRIPTION
Instead we get shiny new pet names for our pet services!

The documentation examples assumed static responses, so made them more vague.