### PR TITLE
Release v0.10.0 - deps: tracing-subscriber @ 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ version = "0.4"
 optional = true
 
 [dependencies.tracing-subscriber]
-version = "0.2"
+version = "0.3"
 optional = true
 default-features = false
 features = ["env-filter", "registry"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "preroll"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     "Jeremiah Senkpiel <fishrock123@rocketmail.com>",
 ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0]
+
+### Dependencies
+
+- Update to preroll 0.10
+- Update to tracing-subscriber 0.3
+
 ## [0.9.0] - 2021-10-28
 
 This release changes test database naming inference and `/monitor/ping` output.

--- a/src/middleware/honeycomb/propagation.rs
+++ b/src/middleware/honeycomb/propagation.rs
@@ -156,13 +156,13 @@ mod tests {
         };
         assert_eq!(
             p.marshal_trace_context(),
-            "1;trace_id=abcdef123456,parent_id=0102030405,context=eyJ1c2VySUQiOjEsImVycm9yTXNnIjoiZmFpbGVkIHRvIHNpZ24gb24iLCJ0b1JldHJ5Ijp0cnVlfQ=="
+            "1;trace_id=abcdef123456,parent_id=0102030405,context=eyJlcnJvck1zZyI6ImZhaWxlZCB0byBzaWduIG9uIiwidG9SZXRyeSI6dHJ1ZSwidXNlcklEIjoxfQ=="
         );
 
         p.dataset = "dada".to_string();
         assert_eq!(
             p.marshal_trace_context(),
-            "1;trace_id=abcdef123456,parent_id=0102030405,dataset=dada,context=eyJ1c2VySUQiOjEsImVycm9yTXNnIjoiZmFpbGVkIHRvIHNpZ24gb24iLCJ0b1JldHJ5Ijp0cnVlfQ=="
+            "1;trace_id=abcdef123456,parent_id=0102030405,dataset=dada,context=eyJlcnJvck1zZyI6ImZhaWxlZCB0byBzaWduIG9uIiwidG9SZXRyeSI6dHJ1ZSwidXNlcklEIjoxfQ=="
         );
     }
 


### PR DESCRIPTION
This PR pulls in the changes from https://github.com/eaze/tracing-honeycomb/pull/14 by updating `tracing-subscriber` to `v0.3.x`. The version of `tracing-honeycomb` stays at `0.3.x` since `tracing-honeycomb` had a patch-level release.

I tested this out as a beta version in a geolocality deploy and it worked well! Things are looking good for a release.