### PR TITLE
Disable the `clap` feature of petname

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,17 @@
 [workspace]
-members = [
-    "preroll-example",
-]
+members = ["preroll-example"]
 
 [package]
 name = "preroll"
 version = "0.10.0"
-authors = [
-    "Jeremiah Senkpiel <fishrock123@rocketmail.com>",
-]
+authors = ["Jeremiah Senkpiel <fishrock123@rocketmail.com>"]
 edition = "2021"
 license = "BlueOak-1.0.0"
 description = "Easy boilerplate utilities for Rust http services which use async-std, Tide, Surf, and friends."
 readme = "README.md"
 repository = "https://github.com/eaze/preroll"
 keywords = ["tide", "surf", "sqlx", "honeycomb"]
-categories = [
-  "web-programming::http-server"
-]
+categories = ["web-programming::http-server"]
 
 [package.metadata.docs.rs]
 features = ["docs"]
@@ -26,26 +20,26 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 docs = ["all"]
 test = []
-
 lambda-http = ["tide-lambda-listener"]
-
 custom_middleware = []
-
 ## Add-ons
 all = ["honeycomb", "postgres"] # All add-ons
-
 honeycomb = ["_beeline", "_tracing", "libhoney-rust"]
 _beeline = ["base64", "thiserror"]
-_tracing = ["tracing", "tracing-futures", "tracing-honeycomb", "tracing-subscriber"]
-
+_tracing = [
+    "tracing",
+    "tracing-futures",
+    "tracing-honeycomb",
+    "tracing-subscriber"
+]
 postgres = ["sqlx", "tide-sqlx"]
-
 ## Internal features
 panic-on-error = []
 
 [dependencies]
 anyhow = "1.0"
 cfg-if = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
 color-eyre = "0.5"
 dotenv = "0.15"
 env_logger = "0.9"
@@ -54,8 +48,20 @@ kv-log-macro = "1.0"
 lazy_static = "1.4"
 log = "0.4"
 once_cell = "1.5"
+petname = { version = "1.1.2", default-features = false, features = [
+    "std_rng",
+    "default_dictionary"
+] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-petname = "1.1.1"
+tide = { version = "0.16", default-features = false, features = ["h1-server"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }
+## feature = tracing
+# stuff copied from the unpublished beeline-rust
+base64 = { version = "0.13", optional = true }
+thiserror = { version = "1.0", optional = true }
+tracing-honeycomb = { version = "0.4", optional = true }
+libhoney-rust = { version = "0.1.4", optional = true }
 
 [dependencies.async-std]
 version = "1.8"
@@ -73,39 +79,21 @@ features = [
     "pin-project-lite",
 ]
 
-[dependencies.chrono]
-version = "0.4"
-features = ["serde"]
-
 [dependencies.http-client]
 version = "6.5.1"
 default-features = false
 features = ["h1_client", "rustls"]
-
-[dependencies.serde]
-version = "1.0"
-features = ["derive"]
 
 [dependencies.surf]
 version = "2.3"
 default-features = false
 features = ["h1-client-rustls", "encoding"]
 
-[dependencies.tide]
-version = "0.16"
-default-features = false
-features = ["h1-server"]
-
 [dependencies.tide-lambda-listener]
 version = "0.1.3"
 optional = true
 
-[dependencies.uuid]
-version = "0.8"
-features = ["serde", "v4"]
-
 ## feature = postgres
-
 [dependencies.sqlx]
 version = "0.5"
 optional = true
@@ -117,34 +105,14 @@ optional = true
 default-features = false
 features = ["rustls", "postgres", "tracing"]
 
-## feature = tracing
-
-# stuff copied from the unpublished beeline-rust
-[dependencies.base64]
-version = "0.13"
-optional = true
-
-[dependencies.thiserror]
-version = "1.0"
-optional = true
-# -- beeline-rust
-
-[dependencies.libhoney-rust]
-version = "0.1.4"
-optional = true
 # default-features = false
 # features = ["runtime-async-std"]
-
 [dependencies.tracing]
 version = "0.1"
 optional = true
 
 [dependencies.tracing-futures]
 version = "0.2"
-optional = true
-
-[dependencies.tracing-honeycomb]
-version = "0.4"
 optional = true
 
 [dependencies.tracing-subscriber]
@@ -154,14 +122,11 @@ default-features = false
 features = ["env-filter", "registry"]
 
 # Dev-deps
-
 [dev-dependencies.cargo-husky]
 version = "1"
 default-features = false
 features = ["user-hooks"]
-
 # Dependency overrides
-
 # [patch.crates-io.libhoney-rust]
 # git = "https://github.com/eaze/libhoney-rust.git"
 # branch = "runtime-async-std"


### PR DESCRIPTION
The new `cargo build --timings` feature informed me that the longest part of an echolibrium build was building `clap`, which is a big surprise because we, uh, don't need clap for our services. This is easily remedied by turning off the default feature of `petname`.

While I was there, restructured the deps in Cargo.toml a bit to pull the less complex ones up in to the main list. The exploded version of the dependencies is harder to read. IMO. Then I ran Bodil's TOML formatter on it.